### PR TITLE
Add initial Deal Room schema and API scaffolding

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -3,11 +3,14 @@
 
 from fastapi import FastAPI
 from routes.api_occupancy_dashboard import router as kpi_router
+from routes.api_deals import router as deals_router
 
 app = FastAPI(title="Altus Empire Command Center API")
 
 # Mount KPI route
 app.include_router(kpi_router)
+# Mount Deal routes
+app.include_router(deals_router)
 
 @app.get("/")
 def health():

--- a/api/routes/api_deals.py
+++ b/api/routes/api_deals.py
@@ -1,0 +1,36 @@
+# api_deals.py
+# 🔌 Routes for Deal Room operations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from supabase import create_client
+import os
+
+router = APIRouter()
+
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+
+class Deal(BaseModel):
+    name: str
+    status: str | None = "draft"
+
+@router.get("/api/deals")
+def list_deals():
+    response = supabase.table("deals").select("*").execute()
+    return response.data
+
+@router.post("/api/deals")
+def create_deal(deal: Deal):
+    response = supabase.table("deals").insert(deal.dict()).execute()
+    if not response.data:
+        raise HTTPException(status_code=400, detail="Failed to create deal")
+    return response.data[0]
+
+@router.get("/api/deals/{deal_id}")
+def get_deal(deal_id: int):
+    response = supabase.table("deals").select("*").eq("id", deal_id).single().execute()
+    if not response.data:
+        raise HTTPException(status_code=404, detail="Deal not found")
+    return response.data

--- a/docs/deal_room_components.md
+++ b/docs/deal_room_components.md
@@ -1,0 +1,7 @@
+# Deal Room UI Components
+
+- **DealDashboard**: Main page displaying all deals and providing controls to create new deals.
+- **DealCard**: Compact representation of a deal used within dashboards to show name, status, and key metrics.
+- **DealDetailView**: Detailed page for a single deal showing financials, documents, and related investors.
+- **InvestorTable**: Table component listing investors associated with a deal and their commitment amounts.
+- **DealForm**: Form dialog used to create or edit the core metadata for a deal.

--- a/scripts/on_deal_created.py
+++ b/scripts/on_deal_created.py
@@ -1,0 +1,28 @@
+# on_deal_created.py
+# 🪝 Azure Function to create Dropbox folders when a new deal is inserted
+
+import logging
+import os
+import requests
+import azure.functions as func
+
+DROPBOX_API_URL = "https://api.dropboxapi.com/2/files/create_folder_v2"
+
+
+def main(event: func.EventGridEvent):
+    """Triggered when a new deal is inserted into the Supabase 'deals' table."""
+    deal = event.get_json()["record"]["new"]
+    deal_name = deal["name"].lower().replace(" ", "-")
+    folder_path = f"/04_Deal_Room/{deal_name}-{deal['id']}"
+
+    headers = {
+        "Authorization": f"Bearer {os.environ['DROPBOX_ACCESS_TOKEN']}",
+        "Content-Type": "application/json",
+    }
+    body = {"path": folder_path, "autorename": False}
+
+    resp = requests.post(DROPBOX_API_URL, headers=headers, json=body)
+    if resp.status_code != 200:
+        logging.error("Dropbox folder creation failed: %s %s", resp.status_code, resp.text)
+    else:
+        logging.info("Created Dropbox folder at %s", folder_path)

--- a/sql/deal_room_schema.sql
+++ b/sql/deal_room_schema.sql
@@ -1,0 +1,27 @@
+-- deal_room_schema.sql
+-- SQL definitions for Deal Room tables
+
+create table if not exists public.deals (
+    id bigint generated always as identity primary key,
+    name text not null,
+    status text not null default 'draft',
+    created_at timestamptz default timezone('utc'::text, now()),
+    updated_at timestamptz default timezone('utc'::text, now())
+);
+
+create table if not exists public.investors (
+    id bigint generated always as identity primary key,
+    full_name text not null,
+    email text unique,
+    phone text,
+    created_at timestamptz default timezone('utc'::text, now())
+);
+
+create table if not exists public.deal_investments (
+    id bigint generated always as identity primary key,
+    deal_id bigint not null references public.deals(id) on delete cascade,
+    investor_id bigint not null references public.investors(id) on delete cascade,
+    amount numeric,
+    created_at timestamptz default timezone('utc'::text, now()),
+    unique (deal_id, investor_id)
+);


### PR DESCRIPTION
## Summary
- define Deal Room tables for deals, investors, and commitments
- scaffold FastAPI deal endpoints and register them in the main app
- outline Azure Function for Dropbox folder creation on new deals
- sketch core React components for Deal Room UI

## Testing
- `pytest` *(fails: ProxyError: HTTPSConnectionPool(host='app.doorloop.com', port=443): Max retries exceeded with url: /api/api/properties (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*

------
https://chatgpt.com/codex/tasks/task_e_6896a0378a648330bf46640a67bb708d